### PR TITLE
fix: resolve ESM import error with chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "commander": "^11.0.0",
     "fs-extra": "^11.0.0",
     "inquirer": "^9.0.0"


### PR DESCRIPTION
Fixes the ERR_REQUIRE_ESM error when running `aidev --version` by downgrading chalk from v5 to v4.1.2.

Chalk v5+ is ESM-only and cannot be imported using CommonJS require() statements. The project uses CommonJS module compilation, so downgrading to v4.1.2 maintains compatibility.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)